### PR TITLE
Have the h1 before the row

### DIFF
--- a/templates/common/donate.html
+++ b/templates/common/donate.html
@@ -3,8 +3,8 @@
 
 
 {% block content %}
-<div class="row" align="center">
-  <h1>Support the project</h1>
+<h1>Support the project</h1>
+<div class="row">
   <div class="col-md-12">
     <p>
       Lutris is a not-for-profit project that relies on the support of the


### PR DESCRIPTION
To match the design of the other pages, have the h1 before the `.row` , without the center.